### PR TITLE
Change for loop to memset

### DIFF
--- a/afsk/main.c
+++ b/afsk/main.c
@@ -106,12 +106,8 @@ int main(void) {
     initializeSpi();
 
     int tlm[7][5];
-    int i, j;
-    for (i = 1; i < 7; i++) {
-        for (j = 1; j < 5; j++) {
-		tlm[i][j] = 0;
-	}
-    }
+    memset(tlm, 0, sizeof tlm);
+
     timestamp = time(NULL);
 	
     int file_i2c;


### PR DESCRIPTION
I wasn't entirely sure whether or not there was a reason to start the iterators at 1. If it was meant for the entire array to be zeroed out then this does that. If not, then I can revert the change on my end and then document why those iterators start at 1.